### PR TITLE
Use a common class Wrapper and IterWrapper to wrap native resource.

### DIFF
--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -26,11 +26,11 @@ ext {
 
 apply from: 'publish.gradle'
 android {
-    compileSdk 32
+    compileSdk 33
 
     defaultConfig {
 
-        minSdk 21
+        minSdk 33
         targetSdk 32
         versionCode 1
         versionName "1.0"
@@ -285,7 +285,7 @@ task checkCurrentJavaVersion() {
 
 task generateHeaderFilesFromJavaWrapper(type: Exec) {
     workingDir "${projectDir}/src/main/java/org/kiwix/"
-    commandLine 'bash', '-c', "javac -h ${buildDir}/include/javah_generated/ -d ${buildDir}/libzim/ ${getLibzimFiles()} ${getLibkiwixFiles()}"
+    commandLine 'bash', '-c', "javac -h ${buildDir}/include/javah_generated/ -d ${buildDir}/libzim/ *.java ${getLibzimFiles()} ${getLibkiwixFiles()}"
 }
 
 String getLibkiwixFiles() {

--- a/lib/src/main/cpp/CMakeLists.txt
+++ b/lib/src/main/cpp/CMakeLists.txt
@@ -10,6 +10,7 @@ add_library(
         zim_wrapper
 
         SHARED
+        wrapper.cpp
         libzim/archive.cpp
         libzim/entry.cpp
         libzim/entry_iterator.cpp
@@ -45,6 +46,7 @@ add_library(
         kiwix_wrapper
 
         SHARED
+        wrapper.cpp
         libkiwix/book.cpp
         libkiwix/filter.cpp
         libkiwix/kiwixicu.cpp

--- a/lib/src/main/cpp/libkiwix/book.cpp
+++ b/lib/src/main/cpp/libkiwix/book.cpp
@@ -29,12 +29,10 @@
 #define TYPENAME libkiwix_Book
 #include <macros.h>
 
-METHOD0(void, allocate)
+METHOD0(jobject, getNativeBook)
 {
-  SET_PTR(std::make_shared<NATIVE_TYPE>());
+  return NEW_RESOURCE(std::make_shared<NATIVE_TYPE>());
 }
-
-DISPOSE
 
 METHOD(void, update__Lorg_kiwix_libkiwix_Book_2, jobject otherBook)
 {
@@ -93,12 +91,12 @@ METHOD0(jobjectArray, getIllustrations) {
   jobjectArray retArray = createArray(env, illustrations.size(), "org/kiwix/libkiwix/Illustration");
   size_t index = 0;
   for (auto illu: illustrations) {
-    auto wrapper = BUILD_WRAPPER("org/kiwix/libkiwx/Illustration", illu);
+    auto wrapper = BUILD_WRAPPER(illu);
     env->SetObjectArrayElement(retArray, index++, wrapper);
   }
   return retArray;
 }
 
 METHOD(jobject, getIllustration, jint size) {
-  return BUILD_WRAPPER("org/kiwix/libkiwix/Illustration", THIS->getIllustration(TO_C(size)));
+  return BUILD_WRAPPER(THIS->getIllustration(TO_C(size)));
 }

--- a/lib/src/main/cpp/libkiwix/bookmark.cpp
+++ b/lib/src/main/cpp/libkiwix/bookmark.cpp
@@ -26,14 +26,12 @@
 
 #define NATIVE_TYPE kiwix::Bookmark
 #define TYPENAME libkiwix_Bookmark
-#include <macros.h>
+#include "macros.h"
 
-METHOD0(void, setNativeBookmark)
+METHOD0(jobject, buildNativeBookmark)
 {
-  SET_PTR(std::make_shared<NATIVE_TYPE>());
+  return NEW_RESOURCE(std::make_shared<NATIVE_TYPE>());
 }
-
-DISPOSE
 
 GETTER(jstring, getBookId)
 

--- a/lib/src/main/cpp/libkiwix/filter.cpp
+++ b/lib/src/main/cpp/libkiwix/filter.cpp
@@ -28,14 +28,10 @@
 #define TYPENAME libkiwix_Filter
 #include "macros.h"
 
-
-
 /* Kiwix Reader JNI functions */
-METHOD0(void, allocate) {
-  SET_PTR(std::make_shared<NATIVE_TYPE>());
+METHOD0(jobject, getNativeFilter) {
+  return NEW_RESOURCE(std::make_shared<NATIVE_TYPE>());
 }
-
-DISPOSE
 
 #define FORWARD(name, args_type) \
 METHOD(jobject, name, args_type value) { \

--- a/lib/src/main/cpp/libkiwix/kiwixserver.cpp
+++ b/lib/src/main/cpp/libkiwix/kiwixserver.cpp
@@ -32,20 +32,13 @@
 
 
 /* Kiwix Reader JNI functions */
-METHOD(void, setNativeServer, jobject jLibrary)
+METHOD(jobject, buildNativeServer, jobject jLibrary)
 {
   LOG("Attempting to create server");
-  try {
-    auto library = getPtr<kiwix::Library>(env, jLibrary);
-    SET_PTR(std::make_shared<NATIVE_TYPE>(library.get()));
-  } catch (std::exception& e) {
-    LOG("Error creating the server");
-    LOG("%s", e.what());
-  }
+  auto library = getPtr<kiwix::Library>(env, jLibrary);
+  return NEW_RESOURCE(std::make_shared<NATIVE_TYPE>(library.get()));
 }
 
-
-DISPOSE
 
 /* Kiwix library functions */
 METHOD(void, setRoot, jstring root)

--- a/lib/src/main/cpp/libkiwix/library.cpp
+++ b/lib/src/main/cpp/libkiwix/library.cpp
@@ -29,12 +29,11 @@
 #include "macros.h"
 
 /* Kiwix Reader JNI functions */
-METHOD0(void, setNativeHandler)
+METHOD0(jobject, buildNativeLibrary)
 {
-  SET_PTR(std::make_shared<NATIVE_TYPE>());
+  return NEW_RESOURCE(std::make_shared<NATIVE_TYPE>());
 }
 
-DISPOSE
 
 /* Kiwix library functions */
 METHOD(jboolean, addBook, jobject book)
@@ -50,11 +49,11 @@ METHOD(jboolean, addBook, jobject book)
 }
 
 METHOD(jobject, getBookById, jstring id) {
-  return BUILD_WRAPPER("org/kiwix/libkiwix/Book", THIS->getBookById(TO_C(id)));
+  return BUILD_WRAPPER(THIS->getBookById(TO_C(id)));
 }
 
 METHOD(jobject, getArchiveById, jstring id) {
-  return BUILD_WRAPPER("org/kiwix/libzim/Archive", THIS->getArchiveById(TO_C(id)));
+  return BUILD_WRAPPER(THIS->getArchiveById(TO_C(id)));
 }
 
 METHOD(jboolean, removeBookById, jstring id) {
@@ -98,7 +97,7 @@ METHOD(jobjectArray, getBookmarks, jboolean onlyValidBookmarks) {
   jobjectArray retArray = createArray(env, bookmarks.size(), "org/kiwix/libkiwix/Bookmark");
   size_t index = 0;
   for (auto bookmark: bookmarks) {
-    auto wrapper = BUILD_WRAPPER("org/kiwix/libkiwx/Bookmark", bookmark);
+    auto wrapper = BUILD_WRAPPER(bookmark);
     env->SetObjectArrayElement(retArray, index++, wrapper);
   }
   return retArray;

--- a/lib/src/main/cpp/libkiwix/manager.cpp
+++ b/lib/src/main/cpp/libkiwix/manager.cpp
@@ -28,13 +28,11 @@
 #define TYPENAME libkiwix_Manager
 #include <macros.h>
 
-METHOD(void, allocate, jobject libraryObj)
+METHOD(jobject, buildNativeManager, jobject libraryObj)
 {
   auto lib = getPtr<kiwix::Library>(env, libraryObj);
-  SET_PTR(std::make_shared<NATIVE_TYPE>(lib.get()));
+  return NEW_RESOURCE(std::make_shared<NATIVE_TYPE>(lib.get()));
 }
-
-DISPOSE
 
 /* Kiwix manager functions */
 METHOD(jboolean, readFile, jstring path)

--- a/lib/src/main/cpp/libzim/blob.cpp
+++ b/lib/src/main/cpp/libzim/blob.cpp
@@ -33,8 +33,6 @@
 #define TYPENAME libzim_Blob
 #include <macros.h>
 
-DISPOSE
-
 METHOD0(jstring, getData) {
   return TO_JNI(std::string(*THIS));
 }

--- a/lib/src/main/cpp/libzim/entry.cpp
+++ b/lib/src/main/cpp/libzim/entry.cpp
@@ -34,20 +34,17 @@
 #define TYPENAME libzim_Entry
 #include <macros.h>
 
-
-DISPOSE
-
 GETTER(jboolean, isRedirect)
 GETTER(jstring, getTitle)
 GETTER(jstring, getPath)
 METHOD(jobject, getItem, jboolean follow) {
-  return BUILD_WRAPPER("org/kiwix/libzim/Item", THIS->getItem(TO_C(follow)));
+  return BUILD_WRAPPER(THIS->getItem(TO_C(follow)));
 }
 
 METHOD0(jobject, getRedirect) {
-  return BUILD_WRAPPER("org/kiwix/libzim/Item", THIS->getRedirect());
+  return BUILD_WRAPPER(THIS->getRedirect());
 }
 
 METHOD0(jobject, getRedirectEntry) {
-  return BUILD_WRAPPER("org/kiwix/libzim/Entry", THIS->getRedirectEntry());
+  return BUILD_WRAPPER(THIS->getRedirectEntry());
 }

--- a/lib/src/main/cpp/libzim/entry_iterator.cpp
+++ b/lib/src/main/cpp/libzim/entry_iterator.cpp
@@ -43,44 +43,24 @@ inline int get_order(JNIEnv* env, jobject thisObj) {
   return TO_C(env->GetIntField(thisObj, fieldId));
 }
 
-METHOD0(void, dispose)
-{
-  // Delete end iterator
-  switch (get_order(env, thisObj)) {
-    case 0:
-       dispose<PATH_NATIVE_TYPE>(env, thisObj, "nativeHandleEnd");
-       dispose<PATH_NATIVE_TYPE>(env, thisObj);
-       break;
-    case 1:
-      dispose<TITLE_NATIVE_TYPE>(env, thisObj, "nativeHandleEnd");
-      dispose<TITLE_NATIVE_TYPE>(env, thisObj);
-      break;
-    case 2:
-      dispose<EFFICIENT_NATIVE_TYPE>(env, thisObj, "nativeHandleEnd");
-      dispose<EFFICIENT_NATIVE_TYPE>(env, thisObj);
-      break;
-  }
-}
-
-
 METHOD0(jboolean, hasNext) {
   switch (get_order(env, thisObj)) {
     case 0: {
-      PATH_NATIVE_TYPE next(*GET_PTR(PATH_NATIVE_TYPE));
+      PATH_NATIVE_TYPE next(*getPtr<PATH_NATIVE_TYPE>(env, thisObj, "nativeResourceBegin"));
       next++;
-      auto end = getPtr<PATH_NATIVE_TYPE>(env, thisObj, "nativeHandleEnd");
+      auto end = getPtr<PATH_NATIVE_TYPE>(env, thisObj, "nativeResourceEnd");
       return next == *end;
     }
     case 1: {
-      TITLE_NATIVE_TYPE next(*GET_PTR(TITLE_NATIVE_TYPE));
+      TITLE_NATIVE_TYPE next(*getPtr<TITLE_NATIVE_TYPE>(env, thisObj, "nativeResourceBegin"));
       next++;
-      auto end = getPtr<TITLE_NATIVE_TYPE>(env, thisObj, "nativeHandleEnd");
+      auto end = getPtr<TITLE_NATIVE_TYPE>(env, thisObj, "nativeResourceEnd");
       return next == *end;
     }
     case 2: {
-      EFFICIENT_NATIVE_TYPE next(*GET_PTR(EFFICIENT_NATIVE_TYPE));
+      EFFICIENT_NATIVE_TYPE next(*getPtr<EFFICIENT_NATIVE_TYPE>(env, thisObj, "nativeResourceBegin"));
       next++;
-      auto end = getPtr<EFFICIENT_NATIVE_TYPE>(env, thisObj, "nativeHandleEnd");
+      auto end = getPtr<EFFICIENT_NATIVE_TYPE>(env, thisObj, "nativeResourceEnd");
       return next == *end;
     }
     default:
@@ -92,19 +72,19 @@ METHOD0(jboolean, hasNext) {
 METHOD0(jobject, next) {
   switch (get_order(env, thisObj)) {
     case 0: {
-      (*GET_PTR(PATH_NATIVE_TYPE))++;
-      zim::Entry entry = **GET_PTR(PATH_NATIVE_TYPE);
-      return BUILD_WRAPPER("org/kiwix/libzim/Entry", entry);
+      (*getPtr<PATH_NATIVE_TYPE>(env, thisObj, "nativeResourceBegin"))++;
+      zim::Entry entry = **getPtr<PATH_NATIVE_TYPE>(env, thisObj, "nativeResourceBegin");
+      return BUILD_WRAPPER(entry);
     }
     case 1: {
-      (*GET_PTR(TITLE_NATIVE_TYPE))++;
-      zim::Entry entry = **GET_PTR(TITLE_NATIVE_TYPE);
-      return BUILD_WRAPPER("org/kiwix/libzim/Entry", entry);
+      (*getPtr<TITLE_NATIVE_TYPE>(env, thisObj, "nativeResourceBegin"))++;
+      zim::Entry entry = **getPtr<TITLE_NATIVE_TYPE>(env, thisObj, "nativeResourceBegin");
+      return BUILD_WRAPPER(entry);
     }
     case 2: {
-      (*GET_PTR(EFFICIENT_NATIVE_TYPE))++;
-      zim::Entry entry = **GET_PTR(EFFICIENT_NATIVE_TYPE);
-      return BUILD_WRAPPER("org/kiwix/libzim/Entry", entry);
+      (*getPtr<EFFICIENT_NATIVE_TYPE>(env, thisObj, "nativeResourceBegin"))++;
+      zim::Entry entry = **getPtr<EFFICIENT_NATIVE_TYPE>(env, thisObj, "nativeResourceBegin");
+      return BUILD_WRAPPER(entry);
     }
     default:
       // unreachable!()

--- a/lib/src/main/cpp/libzim/item.cpp
+++ b/lib/src/main/cpp/libzim/item.cpp
@@ -33,21 +33,20 @@
 #define TYPENAME libzim_Item
 #include <macros.h>
 
-DISPOSE
-
 GETTER(jstring, getTitle)
 GETTER(jstring, getPath)
 GETTER(jstring, getMimetype)
 
 METHOD0(jobject, getData) {
-  return BUILD_WRAPPER("org/kiwix/libzim/Blob", THIS->getData());
+  return BUILD_WRAPPER(THIS->getData());
 }
 
 GETTER(jlong, getSize)
 
 
 METHOD0(jobject, getDirectAccessInformation) {
-  jobject directObjInfo = newObject("org/kiwix/libzim/DirectAccessInfo", env);
+  //return BUILD_WRAPPER(THIS->getDirectAccessInformation());
+  jobject directObjInfo = NEW_OBJECT("org/kiwix/libzim/DirectAccessInfo");
   setDaiObjValue("", 0, directObjInfo, env);
 
   auto cDirectObjInfo = THIS->getDirectAccessInformation();

--- a/lib/src/main/cpp/libzim/search.cpp
+++ b/lib/src/main/cpp/libzim/search.cpp
@@ -33,17 +33,14 @@
 #define TYPENAME libzim_Search
 #include <macros.h>
 
-DISPOSE
-
 METHOD(jobject, getResults, jint start, jint maxResults) {
   auto results = THIS->getResults(TO_C(start), TO_C(maxResults));
-  auto obj = NEW_OBJECT("ork/kiwix/libzim/SearchIterator");
-  SET_HANDLE(zim::SearchIterator, obj, results.begin());
+  auto beginResource = NEW_RESOURCE(results.begin());
+  auto endResource =  NEW_RESOURCE(results.end());
 
-  // We have to set the nativeHandleEnd but no macro ease our work here.
-  auto end_ptr = std::make_shared<zim::SearchIterator>(results.end());
-  setPtr(env, obj, std::move(end_ptr), "nativeHandleEnd");
-  return obj;
+  jclass wrapperClass = env->FindClass("org/kiwix/libzim/SearchIterator");
+  jmethodID initMethod = env->GetMethodID(wrapperClass, "<init>", "(org/kiwix/Wrapper/Resource;org/kiwix/Wrapper/Resource)V");
+  return env->NewObject(wrapperClass, initMethod, beginResource, endResource);
 }
 
 GETTER(jlong, getEstimatedMatches)

--- a/lib/src/main/cpp/libzim/search_iterator.cpp
+++ b/lib/src/main/cpp/libzim/search_iterator.cpp
@@ -35,14 +35,6 @@
 #include <macros.h>
 
 
-// We cannot use the default macro to implement `dispose` as we need to delete the end handle
-METHOD0(void, dispose)
-{
-  // Delete end iterator
-  dispose<NATIVE_TYPE>(env, thisObj, "nativeHandleEnd");
-  dispose<NATIVE_TYPE>(env, thisObj);
-}
-
 
 GETTER(jstring, getPath)
 GETTER(jstring, getTitle)
@@ -59,13 +51,13 @@ METHOD0(jstring, getZimId) {
 METHOD0(jboolean, hasNext) {
   zim::SearchIterator next(*THIS);
   next++;
-  auto end = getPtr<NATIVE_TYPE>(env, thisObj, "nativeHandleEnd");
+  auto end = getPtr<NATIVE_TYPE>(env, thisObj, "nativeResourceEnd");
   return next == *end;
 }
 
 METHOD0(jobject, next) {
   (*THIS)++;
   zim::Entry entry = **THIS;
-  return BUILD_WRAPPER("org/kiwix/libzim/Entry", entry);
+  return BUILD_WRAPPER(entry);
 }
 

--- a/lib/src/main/cpp/libzim/searcher.cpp
+++ b/lib/src/main/cpp/libzim/searcher.cpp
@@ -33,19 +33,14 @@
 #define TYPENAME libzim_Searcher
 #include <macros.h>
 
-METHOD(void, setNativeSearcher, jobject archive)
+METHOD(jobject, buildNativeSearcher, jobject archive)
 {
   auto cArchive = getPtr<zim::Archive>(env, archive);
-  try {
-    auto searcher = std::make_shared<zim::Searcher>(*cArchive);
-    SET_PTR(searcher);
-  } catch (std::exception& e) {
-    LOG("Cannot create searcher");
-      LOG("%s", e.what());
-  }
+  auto searcher = std::make_shared<zim::Searcher>(*cArchive);
+  return NEW_RESOURCE(searcher);
 }
 
-METHOD(void, setNativeSearcherMulti, jobjectArray archives)
+METHOD(jobject, buildNativeSearcherMulti, jobjectArray archives)
 {
   std::vector<zim::Archive> cArchives;
   jsize nbArchives = env->GetArrayLength(archives);
@@ -54,16 +49,9 @@ METHOD(void, setNativeSearcherMulti, jobjectArray archives)
     auto cArchive = getPtr<zim::Archive>(env, archive);
     cArchives.push_back(*cArchive);
   }
-  try {
-    auto searcher = std::make_shared<zim::Searcher>(cArchives);
-    SET_PTR(searcher);
-  } catch (std::exception& e) {
-    LOG("Cannot create searcher");
-      LOG("%s", e.what());
-  }
+  auto searcher = std::make_shared<zim::Searcher>(cArchives);
+  return NEW_RESOURCE(searcher);
 }
-
-DISPOSE
 
 METHOD(jobject, addArchive, jobject archive) {
   auto cArchive = getPtr<zim::Archive>(env, archive);
@@ -73,7 +61,7 @@ METHOD(jobject, addArchive, jobject archive) {
 
 METHOD(jobject, search, jobject query) {
   auto cQuery = getPtr<zim::Query>(env, query);
-  return BUILD_WRAPPER("org/kiwix/libzim/Search", THIS->search(*cQuery));
+  return BUILD_WRAPPER(THIS->search(*cQuery));
 }
 
 METHOD(void, setVerbose, jboolean verbose) {

--- a/lib/src/main/cpp/libzim/suggestion_item.cpp
+++ b/lib/src/main/cpp/libzim/suggestion_item.cpp
@@ -33,8 +33,6 @@
 #define TYPENAME libzim_SuggestionItem
 #include <macros.h>
 
-DISPOSE
-
 GETTER(jstring, getTitle)
 GETTER(jstring, getPath)
 GETTER(jstring, getSnippet)

--- a/lib/src/main/cpp/libzim/suggestion_iterator.cpp
+++ b/lib/src/main/cpp/libzim/suggestion_iterator.cpp
@@ -33,24 +33,16 @@
 #define TYPENAME libzim_SuggestionIterator
 #include <macros.h>
 
-// We cannot use the default macro to implement `dispose` as we need to delete the end handle
-METHOD0(void, dispose)
-{
-  // Delete end iterator
-  dispose<NATIVE_TYPE>(env, thisObj, "nativeHandleEnd");
-  dispose<NATIVE_TYPE>(env, thisObj);
-}
-
 METHOD0(jboolean, hasNext) {
   NATIVE_TYPE next(*THIS);
   next++;
-  auto end = getPtr<NATIVE_TYPE>(env, thisObj, "nativeHandleEnd");
+  auto end = getPtr<NATIVE_TYPE>(env, thisObj, "nativeResourceEnd");
   return next == *end;
 }
 
 METHOD0(jobject, next) {
   (*THIS)++;
   zim::SuggestionItem item = **THIS;
-  return BUILD_WRAPPER("org/kiwix/libzim/SuggestionItem", item);
+  return BUILD_WRAPPER(item);
 }
 

--- a/lib/src/main/cpp/libzim/suggestion_search.cpp
+++ b/lib/src/main/cpp/libzim/suggestion_search.cpp
@@ -33,17 +33,14 @@
 #define TYPENAME libzim_SuggestionSearch
 #include <macros.h>
 
-DISPOSE
-
 METHOD(jobject, getResults, jint start, jint maxResults) {
   auto results = THIS->getResults(TO_C(start), TO_C(maxResults));
-  auto obj = NEW_OBJECT("ork/kiwix/libzim/SuggestionIterator");
-  SET_HANDLE(zim::SuggestionIterator, obj, results.begin());
+  auto beginResource = NEW_RESOURCE(results.begin());
+  auto endResource =  NEW_RESOURCE(results.end());
 
-  // We have to set the nativeHandleEnd but no macro ease our work here.
-  auto end_ptr = std::make_shared<zim::SuggestionIterator>(results.end());
-  setPtr(env, obj, std::move(end_ptr), "nativeHandleEnd");
-  return obj;
+  jclass wrapperClass = env->FindClass("org/kiwix/libzim/SuggestionIterator");
+  jmethodID initMethod = env->GetMethodID(wrapperClass, "<init>", "(org/kiwix/Wrapper/Resource;org/kiwix/Wrapper/Resource)V");
+  return env->NewObject(wrapperClass, initMethod, beginResource, endResource);
 }
 
 GETTER(jlong, getEstimatedMatches)

--- a/lib/src/main/cpp/libzim/suggestion_searcher.cpp
+++ b/lib/src/main/cpp/libzim/suggestion_searcher.cpp
@@ -33,22 +33,16 @@
 #include <macros.h>
 
 
-METHOD(void, setNativeSearcher, jobject archive)
+METHOD(jobject, buildNativeSearcher, jobject archive)
 {
   auto cArchive = getPtr<zim::Archive>(env, archive);
-  try {
-    auto searcher = std::make_shared<zim::SuggestionSearcher>(*cArchive);
-    SET_PTR(searcher);
-  } catch (std::exception& e) {
-    LOG("Cannot create searcher");
-      LOG("%s", e.what());
-  }
+  auto searcher = std::make_shared<zim::SuggestionSearcher>(*cArchive);
+  return NEW_RESOURCE(searcher);
 }
 
-DISPOSE
-
 METHOD(jobject, suggest, jstring query) {
-  return BUILD_WRAPPER("org/kiwix/libzim/SuggestionSearch", THIS->suggest(TO_C(query)));
+  //return BUILD_WRAPPER("org/kiwix/libzim/SuggestionSearch", THIS->suggest(TO_C(query)));
+  return BUILD_WRAPPER(std::make_shared<zim::SuggestionSearch>(THIS->suggest(TO_C(query))));
 }
 
 METHOD(void, setVerbose, jboolean verbose) {

--- a/lib/src/main/cpp/macros.h
+++ b/lib/src/main/cpp/macros.h
@@ -38,5 +38,3 @@ JNIEXPORT retType JNICALL BUILD_METHOD(TYPENAME ,name) ( \
 #define GETTER(retType, name) METHOD0(retType, name) { \
   return TO_JNI(THIS->name()); \
 }
-
-#define DISPOSE  METHOD0(void, dispose)  { dispose<NATIVE_TYPE>(env, thisObj); }

--- a/lib/src/main/cpp/utils.h
+++ b/lib/src/main/cpp/utils.h
@@ -37,7 +37,324 @@
  #define LOG(...)
 #endif
 
+#include <zim/archive.h>
+#include <book.h>
+
 using std::shared_ptr;
+
+namespace zim {
+  class Blob;
+  class Searcher;
+  class Query;
+  class Search;
+  class SearchIterator;
+  class SuggestionSearcher;
+  class SuggestionSearch;
+  class SuggestionIterator;
+  class SuggestionItem;
+
+  class Entry;
+  class Item;
+}
+
+namespace kiwix {
+  class Library;
+  class Bookmark;
+  class Filter;
+  class Manager;
+  class Server;
+}
+
+enum class type_id :int  {
+  Archive,
+  Iterator_path,
+  Iterator_title,
+  Iterator_efficient,
+  Blob,
+  Searcher,
+  Query,
+  Search,
+  SearchIterator,
+  SuggestionSearcher,
+  SuggestionSearch,
+  SuggestionIterator,
+  SuggestionItem,
+  Entry,
+  Item,
+
+  Library,
+  Filter,
+  Manager,
+  Server,
+  Book,
+  Bookmark,
+  ConstBook,
+  Illustration,
+  ConstIllustration
+};
+
+template<typename T>
+struct WrappedType { };
+
+template<> struct WrappedType<zim::Archive>{
+  static constexpr const type_id ID = type_id::Archive;
+  static constexpr const char* CLASS_NAME =  "org/kiwix/libzim/Archive";
+};
+
+template<> struct WrappedType<zim::Archive::iterator<zim::EntryOrder::pathOrder>>{
+  static constexpr const type_id ID = type_id::Iterator_path;
+  //static constexpr const char* CLASS_NAME =  "org/kiwix/libzim/Archive";
+};
+
+template<> struct WrappedType<zim::Archive::iterator<zim::EntryOrder::titleOrder>>{
+  static constexpr const type_id ID = type_id::Iterator_title;
+  //static constexpr const char* CLASS_NAME =  "org/kiwix/libzim/Archive";
+};
+
+template<> struct WrappedType<zim::Archive::iterator<zim::EntryOrder::efficientOrder>>{
+  static constexpr const type_id ID = type_id::Iterator_efficient;
+  //static constexpr const char* CLASS_NAME =  "org/kiwix/libzim/Archive";
+};
+
+template<> struct WrappedType<zim::Blob>{
+  static constexpr const type_id ID = type_id::Blob;
+  static constexpr const char* const CLASS_NAME = "org/kiwix/libzim/Blob";
+};
+
+template<> struct WrappedType<zim::Searcher>{
+  static constexpr const type_id ID = type_id::Searcher;
+  static constexpr const char* const CLASS_NAME = "org/kiwix/libzim/Searcher";
+};
+
+
+template<> struct WrappedType<zim::Search>{
+  static constexpr const type_id ID = type_id::Search;
+  static constexpr const char* const CLASS_NAME = "org/kiwix/libzim/Search";
+};
+
+template<> struct WrappedType<zim::Query>{
+  static constexpr const type_id ID = type_id::Query;
+  static constexpr const char* const CLASS_NAME = "org/kiwix/libzim/Query";
+};
+
+template<> struct WrappedType<zim::SearchIterator>{
+  static constexpr const type_id ID = type_id::SearchIterator;
+  //static constexpr const char* const CLASS_NAME = "org/kiwix/libzim/Search";
+};
+
+template<> struct WrappedType<zim::SuggestionSearcher>{
+  static constexpr const type_id ID = type_id::SuggestionSearcher;
+  static constexpr const char* const CLASS_NAME = "org/kiwix/libzim/SuggestionSearcher";
+};
+
+template<> struct WrappedType<zim::SuggestionSearch>{
+  static constexpr const type_id ID = type_id::SuggestionSearch;
+  static constexpr const char* const CLASS_NAME = "org/kiwix/libzim/SuggestionSearch";
+};
+
+template<> struct WrappedType<zim::SuggestionIterator>{
+  static constexpr const type_id ID = type_id::SuggestionIterator;
+  //static constexpr const char* const CLASS_NAME = "org/kiwix/libzim/SuggestionIterator";
+};
+
+template<> struct WrappedType<zim::SuggestionItem>{
+  static constexpr const type_id ID = type_id::SuggestionItem;
+  static constexpr const char* const CLASS_NAME = "org/kiwix/libzim/SuggestionItem";
+};
+
+template<> struct WrappedType<zim::Entry>{
+  static constexpr const type_id ID = type_id::Entry;
+  static constexpr const char* const CLASS_NAME = "org/kiwix/libzim/Entry";
+};
+
+template<> struct WrappedType<zim::Item>{
+  static constexpr const type_id ID = type_id::Item;
+  static constexpr const char* const CLASS_NAME = "org/kiwix/libzim/Item";
+};
+
+
+template<> struct WrappedType<kiwix::Library>{
+  static constexpr const type_id ID = type_id::Library;
+  static constexpr const char* const CLASS_NAME = "org/kiwix/libkiwix/Library";
+};
+
+template<> struct WrappedType<kiwix::Bookmark>{
+  static constexpr const type_id ID = type_id::Bookmark;
+  static constexpr const char* const CLASS_NAME = "org/kiwix/libkiwix/Bookmark";
+};
+
+
+template<> struct WrappedType<kiwix::Filter>{
+  static constexpr const type_id ID = type_id::Filter;
+  static constexpr const char* const CLASS_NAME = "org/kiwix/libkiwix/Filter";
+};
+
+template<> struct WrappedType<kiwix::Manager>{
+  static constexpr const type_id ID = type_id::Manager;
+  static constexpr const char* const CLASS_NAME = "org/kiwix/libkiwix/Manager";
+};
+
+template<> struct WrappedType<kiwix::Server>{
+  static constexpr const type_id ID = type_id::Server;
+  static constexpr const char* const CLASS_NAME = "org/kiwix/libkiwix/Server";
+};
+
+template<> struct WrappedType<kiwix::Book>{
+  static constexpr const type_id ID = type_id::Book;
+  static constexpr const char* const CLASS_NAME = "org/kiwix/libkiwix/Book";
+};
+
+template<> struct WrappedType<const kiwix::Book>{
+  static constexpr const type_id ID = type_id::ConstBook;
+  static constexpr const char* const CLASS_NAME = "org/kiwix/libkiwix/Book";
+};
+
+template<> struct WrappedType<kiwix::Book::Illustration>{
+  static constexpr const type_id ID = type_id::Illustration;
+  static constexpr const char* const CLASS_NAME = "org/kiwix/libkiwix/Illustration";
+};
+
+
+template<> struct WrappedType<const kiwix::Book::Illustration>{
+  static constexpr const type_id ID = type_id::ConstIllustration;
+  static constexpr const char* const CLASS_NAME = "org/kiwix/libkiwix/Illustration";
+};
+
+
+inline jfieldID getHandleField(JNIEnv* env, jobject obj, const char* handleName)
+{
+  jclass c = env->GetObjectClass(obj);
+  // J is the type signature for long:
+  return env->GetFieldID(c, handleName, "J");
+}
+
+
+template<typename T>
+inline jobject newResource(JNIEnv* env, T&& reference) {
+  auto ptr = std::make_shared<typename std::remove_reference<T>::type>(std::move(reference));
+  return newResource(env, std::move(ptr));
+}
+
+template<typename T>
+inline jobject newResource(JNIEnv* env, shared_ptr<T>&& ptr) {
+  jclass wrapperClass = env->FindClass("org/kiwix/Wrapper/Resource");
+  jmethodID initMethod = env->GetMethodID(wrapperClass, "<init>", "(IL)V");
+  // allocate a shared_ptr on the head
+  shared_ptr<T>* handle = new shared_ptr<T>(ptr);
+  jobject wrapper = env->NewObject(wrapperClass, initMethod, static_cast<int>(WrappedType<T>::ID), reinterpret_cast<jlong>(handle));
+  return wrapper;
+}
+#define NEW_RESOURCE(SHARED_PTR) newResource(env, std::move(SHARED_PTR));
+
+
+inline void deleteResource(JNIEnv* env, jobject resource) {
+  jclass resourceClass = env->GetObjectClass(resource);
+
+  jfieldID handleFieldId = env->GetFieldID(resourceClass, "nativeHandle", "J");
+  auto handle_ptr = env->GetLongField(resource, handleFieldId);
+
+  // We now need to know the type of the handle.
+  jfieldID typeFieldId = env->GetFieldID(resourceClass, "classid", "I");
+  auto type_id = static_cast<enum type_id>(env->GetIntField(resource, typeFieldId));
+
+  switch (type_id) {
+    case type_id::Archive:
+      delete reinterpret_cast<shared_ptr<zim::Archive>*>(handle_ptr);
+      break;
+    case type_id::Iterator_path:
+      delete reinterpret_cast<shared_ptr<zim::Archive::iterator<zim::EntryOrder::pathOrder>>*>(handle_ptr);
+      break;
+    case type_id::Iterator_title:
+      delete reinterpret_cast<shared_ptr<zim::Archive::iterator<zim::EntryOrder::titleOrder>>*>(handle_ptr);
+      break;
+    case type_id::Iterator_efficient:
+      delete reinterpret_cast<shared_ptr<zim::Archive::iterator<zim::EntryOrder::efficientOrder>>*>(handle_ptr);
+      break;
+    case type_id::Blob:
+      delete reinterpret_cast<shared_ptr<zim::Blob>*>(handle_ptr);
+      break;
+    case type_id::Searcher:
+      delete reinterpret_cast<shared_ptr<zim::Searcher>*>(handle_ptr);
+      break;
+    case type_id::Query:
+      delete reinterpret_cast<shared_ptr<zim::Query>*>(handle_ptr);
+      break;
+    case type_id::Search:
+      delete reinterpret_cast<shared_ptr<zim::Search>*>(handle_ptr);
+      break;
+    case type_id::SearchIterator:
+      delete reinterpret_cast<shared_ptr<zim::SearchIterator>*>(handle_ptr);
+      break;
+    case type_id::SuggestionSearcher:
+      delete reinterpret_cast<shared_ptr<zim::SuggestionSearcher>*>(handle_ptr);
+      break;
+    case type_id::SuggestionSearch:
+      delete reinterpret_cast<shared_ptr<zim::SuggestionSearch>*>(handle_ptr);
+      break;
+    case type_id::SuggestionIterator:
+      delete reinterpret_cast<shared_ptr<zim::SuggestionIterator>*>(handle_ptr);
+      break;
+    case type_id::SuggestionItem:
+      delete reinterpret_cast<shared_ptr<zim::SuggestionItem>*>(handle_ptr);
+      break;
+    case type_id::Entry:
+      delete reinterpret_cast<shared_ptr<zim::Entry>*>(handle_ptr);
+      break;
+    case type_id::Item:
+      delete reinterpret_cast<shared_ptr<zim::Item>*>(handle_ptr);
+      break;
+
+    case type_id::Library:
+      delete reinterpret_cast<shared_ptr<kiwix::Library>*>(handle_ptr);
+      break;
+    case type_id::Bookmark:
+      delete reinterpret_cast<shared_ptr<kiwix::Bookmark>*>(handle_ptr);
+      break;
+    case type_id::Filter:
+      delete reinterpret_cast<shared_ptr<kiwix::Filter>*>(handle_ptr);
+      break;
+    case type_id::Manager:
+      delete reinterpret_cast<shared_ptr<kiwix::Manager>*>(handle_ptr);
+      break;
+    case type_id::Server:
+      delete reinterpret_cast<shared_ptr<kiwix::Server>*>(handle_ptr);
+      break;
+    case type_id::Book:
+      delete reinterpret_cast<shared_ptr<kiwix::Book>*>(handle_ptr);
+      break;
+    case type_id::ConstBook:
+      delete reinterpret_cast<shared_ptr<const kiwix::Book>*>(handle_ptr);
+      break;
+    case type_id::Illustration:
+      delete reinterpret_cast<shared_ptr<kiwix::Book::Illustration>*>(handle_ptr);
+      break;
+    case type_id::ConstIllustration:
+      delete reinterpret_cast<shared_ptr<const kiwix::Book::Illustration>*>(handle_ptr);
+      break;
+  };
+}
+
+template<typename T>
+shared_ptr<T> getPtr(JNIEnv* env, jobject thisObj, const char* resourceField = "nativeResource")
+{
+  jclass thisClass = env->GetObjectClass(thisObj);
+  jfieldID resourceFieldId = env->GetFieldID(thisClass, resourceField, "org/kiwix/Wrapper/Resource");
+  jobject resource = env->GetObjectField(thisObj, resourceFieldId);
+
+  // This may be Wrapper.Resource or IterWrapper.Resource
+  jclass resourceClass = env->GetObjectClass(resource);
+  jfieldID handleFieldId = env->GetFieldID(resourceClass, "nativeHandle", "J");
+  auto handle_ptr = env->GetLongField(resource, handleFieldId);
+
+  // Let's check that asked type is same that the one registered in the resource.
+  jfieldID typeFieldId = env->GetFieldID(resourceClass, "classid", "I");
+  auto type_id = static_cast<enum type_id>(env->GetIntField(resource, typeFieldId));
+  assert(type_id == WrappedType<T>::ID);
+
+  auto handle = reinterpret_cast<shared_ptr<T>*>(handle_ptr);
+  return *handle;
+}
+
 
 // Here is the wrapping structure.
 // All java class wrapping a `Native` instance must contain a pointer (cast as a long (J)) called "nativeHandle".
@@ -58,9 +375,8 @@ inline jobject newObject(const char* className, JNIEnv* env) {
 }
 #define NEW_OBJECT(CLASSNAME) newObject(CLASSNAME, env)
 
-
 // Set the pointer to the wrapped object.
-template<typename T>
+/*template<typename T>
 inline void setPtr(JNIEnv* env, jobject thisObj, shared_ptr<T>&& ptr, const char* handleName = "nativeHandle")
 {
   jclass thisClass = env->GetObjectClass(thisObj);
@@ -71,19 +387,20 @@ inline void setPtr(JNIEnv* env, jobject thisObj, shared_ptr<T>&& ptr, const char
   shared_ptr<T>* handle = new shared_ptr<T>(ptr);
   env->SetLongField(thisObj, fieldId, reinterpret_cast<jlong>(handle));
 }
-#define SET_PTR(SHARED_PTR) setPtr(env, thisObj, std::move(SHARED_PTR))
+#define SET_PTR(SHARED_PTR) setPtr(env, thisObj, std::move(SHARED_PTR))*/
 
 // This create a object and set it in the wrapper
-template<typename T, typename ...Args>
+/*template<typename T, typename ...Args>
 inline void setHandle(JNIEnv* env, jobject thisObj, Args && ...args)
 {
   auto ptr = std::make_shared<T>(std::forward<Args>(args)...);
   setPtr(env, thisObj, std::move(ptr));
 }
-#define SET_HANDLE(NATIVE_TYPE, OBJ, VALUE) setHandle<NATIVE_TYPE>(env, OBJ, VALUE)
+#define SET_HANDLE(NATIVE_TYPE, OBJ, VALUE) setHandle<NATIVE_TYPE>(env, OBJ, VALUE)*/
 
 
 // Return a shared_ptr for the handle
+/*
 template<typename T>
 shared_ptr<T> getPtr(JNIEnv* env, jobject thisObj, const char* handleName = "nativeHandle")
 {
@@ -92,7 +409,7 @@ shared_ptr<T> getPtr(JNIEnv* env, jobject thisObj, const char* handleName = "nat
   auto handle = reinterpret_cast<shared_ptr<T>*>(env->GetLongField(thisObj, fidNumber));
   return *handle;
 }
-#define GET_PTR(NATIVE_TYPE) getPtr<NATIVE_TYPE>(env, thisObj)
+#define GET_PTR(NATIVE_TYPE) getPtr<NATIVE_TYPE>(env, thisObj)*/
 
 // Delete the heap allocated handle
 template<typename T>
@@ -107,12 +424,6 @@ void dispose(JNIEnv* env, jobject thisObj, const char* handleName = "nativeHandl
   env->SetLongField(thisObj, fieldId, 0);
 }
 
-inline jfieldID getHandleField(JNIEnv* env, jobject obj, const char* handleName)
-{
-  jclass c = env->GetObjectClass(obj);
-  // J is the type signature for long:
-  return env->GetFieldID(c, handleName, "J");
-}
 
 inline jobjectArray createArray(JNIEnv* env, size_t length, const std::string& type_sig)
 {
@@ -120,15 +431,28 @@ inline jobjectArray createArray(JNIEnv* env, size_t length, const std::string& t
   return env->NewObjectArray(length, c, NULL);
 }
 
-template<typename T>
-inline jobject buildWrapper(JNIEnv* env, const char* class_name, T&& obj, const char* handleName = "nativeHandle") {
-  auto wrapper = newObject(class_name, env);
-  auto ptr = std::make_shared<T>(std::move(obj));
-  setPtr(env, wrapper, std::move(ptr));
-  return wrapper;
-}
-#define BUILD_WRAPPER(CLASSNAME, OBJ) buildWrapper(env, CLASSNAME, std::move(OBJ))
 
+
+template<typename T>
+inline jobject buildWrapper(JNIEnv* env, std::shared_ptr<T>&& ptr) {
+  auto resource = newResource(env, std::move(ptr));
+  jclass wrapperClass = env->FindClass(WrappedType<T>::CLASS_NAME);
+  jmethodID initMethod = env->GetMethodID(wrapperClass, "<init>", "(org/kiwix/Wrapper/Resource)V");
+  return env->NewObject(wrapperClass, initMethod, resource);
+}
+template<typename T>
+inline jobject buildWrapper(JNIEnv* env, T&& obj) {
+  auto resource = newResource(env, std::move(obj));
+  jclass wrapperClass = env->FindClass(WrappedType<T>::CLASS_NAME);
+  jmethodID initMethod = env->GetMethodID(wrapperClass, "<init>", "(org/kiwix/Wrapper/Resource)V");
+  return env->NewObject(wrapperClass, initMethod, resource);
+}
+#define BUILD_WRAPPER(OBJ) buildWrapper(env, std::move(OBJ))
+
+#define CATCH(MESSAGE) catch (...) { \
+  jclass exceptionClass = env->FindClass("java/lang/RuntimeException"); \
+  env->ThrowNew(exceptionClass, MESSAGE); \
+}
 
 
 // ---------------------------------------------------------------------------

--- a/lib/src/main/cpp/wrapper.cpp
+++ b/lib/src/main/cpp/wrapper.cpp
@@ -20,31 +20,36 @@
 
 #include <jni.h>
 #include <exception>
-#include "org_kiwix_libzim_Searcher.h"
+#include "org_kiwix_Wrapper_Resource.h"
+#include "org_kiwix_IterWrapper_Resource.h"
 
 #include <utils.h>
 
 #include <string>
 
-#include <zim/search.h>
+#include <zim/item.h>
 
-#define CLASSNAME "org/kiwix/libzim/Query"
-#define NATIVE_TYPE zim::Query
-#define TYPENAME libzim_Query
+#define CLASSNAME "org/kiwix/Wrapper"
+#define TYPENAME libzim_Item
 #include <macros.h>
 
-METHOD(jobject, buildNativeQuery, jstring query)
-{
-  return NEW_RESOURCE(std::make_shared<NATIVE_TYPE>(TO_C(query)));
+/*
+ * Class:     org_kiwix_Wrapper_Resource
+ * Method:    dispose
+ * Signature: ()V
+ */
+JNIEXPORT void JNICALL Java_org_kiwix_Wrapper_00024Resource_dispose
+  (JNIEnv *env, jobject resource) {
+  deleteResource(env, resource);
 }
 
-METHOD(jobject, setQuery, jstring query) {
-  THIS->setQuery(TO_C(query));
-  return thisObj;
-}
 
-METHOD(jobject, setGeorange, jfloat latitude, jfloat longitude, jfloat distance) {
-  THIS->setGeorange(TO_C(latitude), TO_C(longitude), TO_C(distance));
-  return thisObj;
+/*
+ * Class:     org_kiwix_IterWrapper_Resource
+ * Method:    dispose
+ * Signature: ()V
+ */
+JNIEXPORT void JNICALL Java_org_kiwix_IterWrapper_00024Resource_dispose
+  (JNIEnv *env , jobject resource) {
+  deleteResource(env, resource);
 }
-

--- a/lib/src/main/java/org/kiwix/IterWrapper.java
+++ b/lib/src/main/java/org/kiwix/IterWrapper.java
@@ -1,0 +1,46 @@
+
+package org.kiwix;
+
+import java.lang.ref.Cleaner;
+
+public class IterWrapper implements AutoCloseable {
+    private static final Cleaner cleaner = Cleaner.create();
+    protected static class Resource implements Runnable {
+        Resource(int classid, long nativeHandle) {
+            this.classid = classid;
+            this.nativeHandle = nativeHandle;
+        }
+
+        public void run() {
+            dispose();
+        }
+        // The pointer (as a long) to the native handle (the shared_ptr)
+        private long nativeHandle;
+
+        // The name of the class.
+        // We need it to cast our pointer to the right type.
+        private int classid;
+
+        // The native method wich will actually delete the cpp resource.
+        private native void dispose();
+    }
+
+
+    private final Resource nativeResourceBegin;
+    private final Cleaner.Cleanable cleanableBegin;
+
+    private final Resource nativeResourceEnd;
+    private final Cleaner.Cleanable cleanableEnd;
+
+    public IterWrapper(Resource resourceBegin, Resource resourceEnd) {
+        this.nativeResourceBegin = resourceBegin;
+        this.cleanableBegin = cleaner.register(this, nativeResourceBegin);
+        this.nativeResourceEnd = resourceEnd;
+        this.cleanableEnd = cleaner.register(this, nativeResourceEnd);
+    }
+
+    public void close() {
+        cleanableBegin.clean();
+        cleanableEnd.clean();
+    }
+}

--- a/lib/src/main/java/org/kiwix/Wrapper.java
+++ b/lib/src/main/java/org/kiwix/Wrapper.java
@@ -1,0 +1,40 @@
+
+package org.kiwix;
+
+import java.lang.ref.Cleaner;
+
+public class Wrapper implements AutoCloseable {
+    private static final Cleaner cleaner = Cleaner.create();
+    protected static class Resource implements Runnable {
+        Resource(int classid, long nativeHandle) {
+            this.classid = classid;
+            this.nativeHandle = nativeHandle;
+        }
+
+        public void run() {
+            dispose();
+        }
+        // The pointer (as a long) to the native handle (the shared_ptr)
+        private long nativeHandle;
+
+        // The name of the class.
+        // We need it to cast our pointer to the right type.
+        private int classid;
+
+        // The native method wich will actually delete the cpp resource.
+        private native void dispose();
+    }
+
+
+    private final Resource nativeResource;
+    private final Cleaner.Cleanable cleanable;
+
+    public Wrapper(Resource resource) {
+        this.nativeResource = resource;
+        this.cleanable = cleaner.register(this, nativeResource);
+    }
+
+    public void close() {
+        cleanable.clean();
+    }
+}

--- a/lib/src/main/java/org/kiwix/libkiwix/Book.java
+++ b/lib/src/main/java/org/kiwix/libkiwix/Book.java
@@ -3,18 +3,14 @@ package org.kiwix.libkiwix;
 
 import org.kiwix.libzim.Archive;
 import org.kiwix.libkiwix.Illustration;
+import org.kiwix.Wrapper;
 
-public class Book
+public class Book extends Wrapper
 {
-  public Book() { allocate(); }
-
+  public Book(Wrapper.Resource res) { super(res); }
 
   public native void update(Book book);
   public native void update(Archive archive);
-
-
-  @Override
-  protected void finalize() { dispose();  }
 
   public native String getId();
   public native String getPath();
@@ -45,8 +41,4 @@ public class Book
 
   public native Illustration[] getIllustrations();
   public native Illustration getIllustration(int size);
-
-  private native void allocate();
-  private native void dispose();
-  private long nativeHandle;
 }

--- a/lib/src/main/java/org/kiwix/libkiwix/Bookmark.java
+++ b/lib/src/main/java/org/kiwix/libkiwix/Bookmark.java
@@ -19,10 +19,12 @@
 
 package org.kiwix.libkiwix;
 
-public class Bookmark
+import org.kiwix.Wrapper;
+
+public class Bookmark extends Wrapper
 {
   public Bookmark() {
-    setNativeBookmark();
+    super(buildNativeBookmark());
   }
 
   public native void setBookId(String bookId);
@@ -39,15 +41,6 @@ public class Bookmark
   public native String getLanguage();
   public native String getDate();
 
-  @Override
-  protected void finalize() { dispose(); }
 
-
-///--------- The wrapper thing
-  // To delete our native wrapper
-  public native void dispose();
-
-  // A pointer (as a long) to a native Handle
-  private native void setNativeBookmark();
-  private long nativeHandle;
+  private native static Wrapper.Resource buildNativeBookmark();
 }

--- a/lib/src/main/java/org/kiwix/libkiwix/Filter.java
+++ b/lib/src/main/java/org/kiwix/libkiwix/Filter.java
@@ -19,8 +19,13 @@
 
 package org.kiwix.libkiwix;
 
-public class Filter
+import org.kiwix.Wrapper;
+
+public class Filter extends Wrapper
 {
+  public Filter() {
+    super(getNativeFilter());
+  }
 
   public native Filter local(boolean accept);
   public native Filter remote(boolean accept);
@@ -33,12 +38,5 @@ public class Filter
   public native Filter maxSize(long size);
   public native Filter query(String query);
 
-
-  public Filter() { allocate(); }
-
-  @Override
-  protected void finalize() { dispose(); }
-  private native void allocate();
-  private native void dispose();
-  private long nativeHandle;
+  private native static Wrapper.Resource getNativeFilter();
 }

--- a/lib/src/main/java/org/kiwix/libkiwix/Illustration.java
+++ b/lib/src/main/java/org/kiwix/libkiwix/Illustration.java
@@ -1,7 +1,8 @@
 
 package org.kiwix.libkiwix;
+import org.kiwix.Wrapper;
 
-public class Illustration
+public class Illustration extends Wrapper
 {
   public native int width();
   public native int height();
@@ -9,9 +10,7 @@ public class Illustration
   public native String url();
 
   public native String getData();
-  @Override
-  protected void finalize() { dispose();  }
 
-  private native void dispose();
-  private long nativeHandle;
+
+  private Illustration(Wrapper.Resource res) { super(res); }
 }

--- a/lib/src/main/java/org/kiwix/libkiwix/Library.java
+++ b/lib/src/main/java/org/kiwix/libkiwix/Library.java
@@ -24,12 +24,13 @@ import org.kiwix.libzim.Searcher;
 import org.kiwix.libkiwix.Book;
 import org.kiwix.libkiwix.JNIKiwixException;
 import org.kiwix.libkiwix.Bookmark;
+import org.kiwix.Wrapper;
 
-public class Library
+public class Library extends Wrapper
 {
   public Library()
   {
-    setNativeHandler();
+    super(buildNativeLibrary());
   }
   public native boolean addBook(Book book) throws JNIKiwixException;
 
@@ -58,9 +59,5 @@ public class Library
   public native boolean removeBookmark(String zimId, String url);
   public native Bookmark[] getBookmarks(boolean onlyValidBookmarks);
 
-  @Override
-  protected void finalize() { dispose(); }
-  private native void setNativeHandler();
-  private native void dispose();
-  private long nativeHandle;
+  private native static Wrapper.Resource buildNativeLibrary();
 }

--- a/lib/src/main/java/org/kiwix/libkiwix/Manager.java
+++ b/lib/src/main/java/org/kiwix/libkiwix/Manager.java
@@ -20,8 +20,9 @@
 package org.kiwix.libkiwix;
 
 import org.kiwix.libkiwix.Library;
+import org.kiwix.Wrapper;
 
-public class Manager
+public class Manager extends Wrapper
 {
   /**
    * Read a `library.xml` file and add books in the library.
@@ -76,15 +77,11 @@ public class Manager
                                        boolean checkMetaData);
 
   public Manager(Library library) {
-    allocate(library);
+    super(buildNativeManager(library));
     _library = library;
   }
 
   private Library _library;
 
-  @Override
-  protected void finalize() { dispose(); }
-  private native void allocate(Library library);
-  private native void dispose();
-  private long nativeHandle;
+  private native static Wrapper.Resource buildNativeManager(Library library);
 }

--- a/lib/src/main/java/org/kiwix/libkiwix/Server.java
+++ b/lib/src/main/java/org/kiwix/libkiwix/Server.java
@@ -21,8 +21,9 @@ package org.kiwix.libkiwix;
 
 import org.kiwix.libkiwix.JNIKiwixException;
 import org.kiwix.libkiwix.Library;
+import org.kiwix.Wrapper;
 
-public class Server
+public class Server extends Wrapper
 {
   public native void setRoot(String root);
 
@@ -42,14 +43,8 @@ public class Server
 
   public Server(Library library)
   {
-    setNativeServer(library);
+    super(buildNativeServer(library));
   }
 
-  @Override
-  protected void finalize() { dispose(); }
-
-
-  private native void setNativeServer(Library library);
-  private native void dispose();
-  private long nativeHandle;
+  private native static Wrapper.Resource buildNativeServer(Library library);
 }

--- a/lib/src/main/java/org/kiwix/libzim/Archive.java
+++ b/lib/src/main/java/org/kiwix/libzim/Archive.java
@@ -23,34 +23,26 @@ import org.kiwix.libzim.ZimFileFormatException;
 import org.kiwix.libzim.Entry;
 import org.kiwix.libzim.Item;
 import org.kiwix.libzim.EntryIterator;
+import org.kiwix.Wrapper;
 import java.io.FileDescriptor;
 
-public class Archive
+public class Archive extends Wrapper
 {
 
   public Archive(String filename) throws ZimFileFormatException
   {
-    setNativeArchive(filename);
-    if (nativeHandle == 0) {
-      throw new ZimFileFormatException("Cannot open zimfile "+filename);
-    }
+    super(buildNativeArchive(filename));
   }
 
   public Archive(FileDescriptor fd) throws ZimFileFormatException
   {
-    setNativeArchiveByFD(fd);
-    if (nativeHandle == 0) {
-      throw new ZimFileFormatException("Cannot open zimfile by fd "+fd.toString());
-    }
+    super(buildNativeArchiveByFD(fd));
   }
 
   public Archive(FileDescriptor fd, long offset, long size)
           throws ZimFileFormatException
   {
-    setNativeArchiveEmbedded(fd, offset, size);
-    if (nativeHandle == 0) {
-      throw new ZimFileFormatException(String.format("Cannot open embedded zimfile (fd=%s, offset=%d, size=%d)", fd, offset, size));
-    }
+    super(buildNativeArchiveEmbedded(fd, offset, size));
   }
 
   public native String getFilename();
@@ -100,18 +92,7 @@ public class Archive
   public native EntryIterator findByTitle(String path);
 
 
-  private native void setNativeArchive(String filename);
-  private native void setNativeArchiveByFD(FileDescriptor fd);
-  private native void setNativeArchiveEmbedded(FileDescriptor fd, long offset, long size);
-
-  @Override
-  protected void finalize() { dispose(); }
-
-
-///--------- The wrapper thing
-  // To delete our native wrapper
-  public native void dispose();
-
-  // A pointer (as a long) to a native Handle
-  private long nativeHandle;
+  private native static Wrapper.Resource buildNativeArchive(String filename);
+  private native static Wrapper.Resource buildNativeArchiveByFD(FileDescriptor fd);
+  private native static Wrapper.Resource buildNativeArchiveEmbedded(FileDescriptor fd, long offset, long size);
 }

--- a/lib/src/main/java/org/kiwix/libzim/Blob.java
+++ b/lib/src/main/java/org/kiwix/libzim/Blob.java
@@ -20,21 +20,13 @@
 package org.kiwix.libzim;
 
 import org.kiwix.libzim.Blob;
+import org.kiwix.Wrapper;
 
-public class Blob
+public class Blob extends Wrapper
 {
+  private Blob(Wrapper.Resource res) {
+    super(res);
+  }
   public native String getData();
   public native long size();
-
-
-  @Override
-  protected void finalize() { dispose(); }
-
-
-///--------- The wrapper thing
-  // To delete our native wrapper
-  public native void dispose();
-
-  // A pointer (as a long) to a native Handle
-  private long nativeHandle;
 }

--- a/lib/src/main/java/org/kiwix/libzim/Entry.java
+++ b/lib/src/main/java/org/kiwix/libzim/Entry.java
@@ -20,9 +20,13 @@
 package org.kiwix.libzim;
 
 import org.kiwix.libzim.Item;
+import org.kiwix.Wrapper;
 
-public class Entry
+public class Entry extends Wrapper
 {
+  private Entry(Wrapper.Resource res) {
+    super(res);
+  }
   public native boolean isRedirect();
   public native String getTitle();
   public native String getPath();
@@ -30,14 +34,4 @@ public class Entry
   public native Item getItem(boolean follow);
   public native Item getRedirect();
   public native Entry getRedirectEntry();
-
-  @Override
-  protected void finalize() { dispose(); }
-
-///--------- The wrapper thing
-  // To delete our native wrapper
-  private native void dispose();
-
-  // A pointer (as a long) to a native Handle
-  private long nativeHandle;
 }

--- a/lib/src/main/java/org/kiwix/libzim/EntryIterator.java
+++ b/lib/src/main/java/org/kiwix/libzim/EntryIterator.java
@@ -20,29 +20,17 @@
 package org.kiwix.libzim;
 
 import java.util.Iterator;
+import org.kiwix.IterWrapper;
 
-public class EntryIterator implements Iterator<Entry>
+public class EntryIterator extends IterWrapper implements Iterator<Entry>
 {
-  private EntryIterator(int order) {
+  private EntryIterator(int order, Resource nativeResourceBegin, Resource nativeResourceEnd) {
+    super(nativeResourceBegin, nativeResourceEnd);
     this.order = order;
   }
   public native boolean hasNext();
   public native Entry next();
 
-  @Override
-  protected void finalize() { dispose(); }
-
-
-///--------- The wrapper thing
-  // To delete our native wrapper
-  public native void dispose();
-
   // A marker of the order used for this iterator
   private int order;
-
-  // A pointer (as a long) to a native Handle
-  private long nativeHandle;
-
-  // A pointer (as a long) to the native end
-  private long nativeHandleEnd;
 }

--- a/lib/src/main/java/org/kiwix/libzim/Item.java
+++ b/lib/src/main/java/org/kiwix/libzim/Item.java
@@ -21,9 +21,13 @@ package org.kiwix.libzim;
 
 import org.kiwix.libzim.Blob;
 import org.kiwix.libzim.DirectAccessInfo;
+import org.kiwix.Wrapper;
 
-public class Item
+public class Item extends Wrapper
 {
+  private Item(Wrapper.Resource res) {
+    super(res);
+  }
   public native String getTitle();
   public native String getPath();
   public native String getMimetype();
@@ -32,14 +36,4 @@ public class Item
   public native long getSize();
 
   public native DirectAccessInfo getDirectAccessInformation();
-
-  @Override
-  protected void finalize() { dispose(); }
-
-///--------- The wrapper thing
-  // To delete our native wrapper
-  private native void dispose();
-
-  // A pointer (as a long) to a native Handle
-  private long nativeHandle;
 }

--- a/lib/src/main/java/org/kiwix/libzim/Query.java
+++ b/lib/src/main/java/org/kiwix/libzim/Query.java
@@ -19,24 +19,15 @@
 
 package org.kiwix.libzim;
 
-public class Query
+import org.kiwix.Wrapper;
+
+public class Query extends Wrapper
 {
   public Query(String query) {
-    setNativeQuery(query);
+    super(buildNativeQuery(query));
   }
 
   public native Query setQuery(String query);
   public native Query setGeorange(float latitude, float longitute, float distance);
-
-  @Override
-  protected void finalize() { dispose(); }
-
-
-///--------- The wrapper thing
-  // To delete our native wrapper
-  public native void dispose();
-
-  // A pointer (as a long) to a native Handle
-  private native long setNativeQuery(String query);
-  private long nativeHandle;
+  private native static Wrapper.Resource buildNativeQuery(String query);
 }

--- a/lib/src/main/java/org/kiwix/libzim/Search.java
+++ b/lib/src/main/java/org/kiwix/libzim/Search.java
@@ -20,20 +20,13 @@
 package org.kiwix.libzim;
 
 import org.kiwix.libzim.SearchIterator;
+import org.kiwix.Wrapper;
 
-public class Search
+public class Search extends Wrapper
 {
+  private Search(Wrapper.Resource res) {
+    super(res);
+  }
   public native SearchIterator getResults(int start, int maxResults);
   public native long getEstimatedMatches();
-
-  @Override
-  protected void finalize() { dispose(); }
-
-
-///--------- The wrapper thing
-  // To delete our native wrapper
-  public native void dispose();
-
-  // A pointer (as a long) to a native Handle
-  private long nativeHandle;
 }

--- a/lib/src/main/java/org/kiwix/libzim/SearchIterator.java
+++ b/lib/src/main/java/org/kiwix/libzim/SearchIterator.java
@@ -35,18 +35,4 @@ public class SearchIterator implements Iterator<Entry>
 
   public native boolean hasNext();
   public native Entry next();
-
-
-  @Override
-  protected void finalize() { dispose(); }
-
-///--------- The wrapper thing
-  // To delete our native wrapper
-  public native void dispose();
-
-  // A pointer (as a long) to a native Handle
-  private long nativeHandle;
-
-  // A pointer (as a long) to the native end
-  private long nativeHandleEnd;
 }

--- a/lib/src/main/java/org/kiwix/libzim/Searcher.java
+++ b/lib/src/main/java/org/kiwix/libzim/Searcher.java
@@ -24,41 +24,25 @@ import org.kiwix.libzim.Archive;
 import org.kiwix.libzim.Search;
 import org.kiwix.libzim.Query;
 import java.io.FileDescriptor;
+import org.kiwix.Wrapper;
 
-public class Searcher
+public class Searcher extends Wrapper
 {
 
   public Searcher(Archive archive) throws Exception
   {
-    setNativeSearcher(archive);
-    if (nativeHandle == 0) {
-      throw new Exception("Cannot create searcher");
-    }
+    super(buildNativeSearcher(archive));
   }
 
   public Searcher(Archive[] archives) throws Exception
   {
-    setNativeSearcherMulti(archives);
-    if (nativeHandle == 0) {
-      throw new Exception("Cannot create searcher");
-    }
+    super(buildNativeSearcherMulti(archives));
   }
 
   public native Searcher addArchive(Archive archive);
   public native Search search(Query query);
   public native void setVerbose(boolean verbose);
 
-  private native void setNativeSearcher(Archive archive);
-  private native void setNativeSearcherMulti(Archive[] archives);
-
-  @Override
-  protected void finalize() { dispose(); }
-
-
-///--------- The wrapper thing
-  // To delete our native wrapper
-  public native void dispose();
-
-  // A pointer (as a long) to a native Handle
-  private long nativeHandle;
+  private native static Wrapper.Resource buildNativeSearcher(Archive archive);
+  private native static Wrapper.Resource buildNativeSearcherMulti(Archive[] archives);
 }

--- a/lib/src/main/java/org/kiwix/libzim/SuggestionItem.java
+++ b/lib/src/main/java/org/kiwix/libzim/SuggestionItem.java
@@ -18,21 +18,14 @@
  */
 
 package org.kiwix.libzim;
+import org.kiwix.Wrapper;
 
-public class SuggestionItem
+public class SuggestionItem extends Wrapper
 {
   public native String getTitle();
   public native String getPath();
   public native String getSnippet();
   public native boolean hasSnippet();
 
-  @Override
-  protected void finalize() { dispose(); }
-
-///--------- The wrapper thing
-  // To delete our native wrapper
-  private native void dispose();
-
-  // A pointer (as a long) to a native Handle
-  private long nativeHandle;
+  private SuggestionItem(Wrapper.Resource res) { super(res); }
 }

--- a/lib/src/main/java/org/kiwix/libzim/SuggestionIterator.java
+++ b/lib/src/main/java/org/kiwix/libzim/SuggestionIterator.java
@@ -20,24 +20,13 @@
 package org.kiwix.libzim;
 
 import org.kiwix.libzim.SuggestionItem;
+import org.kiwix.IterWrapper;
 import java.util.Iterator;
 
-public class SuggestionIterator implements Iterator<SuggestionItem>
+public class SuggestionIterator extends IterWrapper implements Iterator<SuggestionItem>
 {
   public native boolean hasNext();
   public native SuggestionItem next();
 
-  @Override
-  protected void finalize() { dispose(); }
-
-
-///--------- The wrapper thing
-  // To delete our native wrapper
-  public native void dispose();
-
-  // A pointer (as a long) to a native Handle
-  private long nativeHandle;
-
-  // A pointer (as a long) to the native end
-  private long nativeHandleEnd;
+  private SuggestionIterator(IterWrapper.Resource begin, IterWrapper.Resource end) { super(begin, end); }
 }

--- a/lib/src/main/java/org/kiwix/libzim/SuggestionSearch.java
+++ b/lib/src/main/java/org/kiwix/libzim/SuggestionSearch.java
@@ -20,20 +20,12 @@
 package org.kiwix.libzim;
 
 import org.kiwix.libzim.SuggestionIterator;
+import org.kiwix.Wrapper;
 
-public class SuggestionSearch
+public class SuggestionSearch extends Wrapper
 {
   public native SuggestionIterator getResults(int start, int maxResults);
   public native long getEstimatedMatches();
 
-
-  @Override
-  protected void finalize() { dispose(); }
-
-///--------- The wrapper thing
-  // To delete our native wrapper
-  public native void dispose();
-
-  // A pointer (as a long) to a native Handle
-  private long nativeHandle;
+  private SuggestionSearch(Wrapper.Resource res) { super(res); }
 }

--- a/lib/src/main/java/org/kiwix/libzim/SuggestionSearcher.java
+++ b/lib/src/main/java/org/kiwix/libzim/SuggestionSearcher.java
@@ -23,31 +23,18 @@ import org.kiwix.libzim.ZimFileFormatException;
 import org.kiwix.libzim.Archive;
 import org.kiwix.libzim.SuggestionSearch;
 import java.io.FileDescriptor;
+import org.kiwix.Wrapper;
 
-public class SuggestionSearcher
+public class SuggestionSearcher extends Wrapper
 {
 
   public SuggestionSearcher(Archive archive) throws Exception
   {
-    setNativeSearcher(archive);
-    if (nativeHandle == 0) {
-      throw new Exception("Cannot create searcher");
-    }
+    super(buildNativeSearcher(archive));
   }
 
   public native SuggestionSearch suggest(String query);
   public native void setVerbose(boolean verbose);
 
-  private native void setNativeSearcher(Archive archive);
-
-
-  @Override
-  protected void finalize() { dispose(); }
-
-///--------- The wrapper thing
-  // To delete our native wrapper
-  public native void dispose();
-
-  // A pointer (as a long) to a native Handle
-  private long nativeHandle;
+  private native static Wrapper.Resource buildNativeSearcher(Archive archive);
 }


### PR DESCRIPTION
Native resource (pointer to shared_ptr) is stored as a long in the `Wrapper.Resource` class.

As Wrapper implements AutoCloseable and we register the (java) resource to be cleaned at object destruction, we now properly delete the native resource.


This also adding new macro to avoid writting the class name and so reduce potential typos.