### PR TITLE
Use libkiwix 12.0.0

### DIFF
--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -21,7 +21,10 @@ ext["sonatypeStagingProfileId"] = properties.getProperty("sonatypeStagingProfile
 ext {
     set("GROUP_ID", "org.kiwix.kiwixlib")
     set("ARTIFACT_ID", "kiwixlib")
-    set("VERSION", "11.0.0")
+    /* Please update the version of java-libkiwix before releasing it,
+     according to the latest version of libkiwix available at https://github.com/kiwix/libkiwix/releases.
+    */
+    set("VERSION", "12.0.0")
 }
 
 apply from: 'publish.gradle'


### PR DESCRIPTION
Fixes #43 
We have now automatically set the version code of `java-libkiwix` on behalf of the libkiwix version, this change makes sure the version of the `java-libkiwix` same as the libkiwix version while releasing the `java-libkiwix` on maven.