### PR TITLE
Changed CMAKE_ANDROID_STL_TYPE to shared 

### DIFF
--- a/lib/src/main/cpp/CMakeLists.txt
+++ b/lib/src/main/cpp/CMakeLists.txt
@@ -79,7 +79,7 @@ endif ()
 
 # Android target
 if (ANDROID)
-        set(CMAKE_ANDROID_STL_TYPE llvm-libc++_static)
+        set(CMAKE_ANDROID_STL_TYPE llvm-libc++_shared)
 
         find_library(
                 log-lib

--- a/lib/src/main/java/org/kiwix/libkiwix/JNIKiwix.java
+++ b/lib/src/main/java/org/kiwix/libkiwix/JNIKiwix.java
@@ -27,6 +27,7 @@ import org.kiwix.libkiwix.JNIICU;
 public class JNIKiwix
 {
   public JNIKiwix(final Context context) {
+    ReLinker.loadLibrary(context, "c++_shared");
     ReLinker.loadLibrary(context, "kiwix");
     ReLinker.loadLibrary(context, "zim");
     ReLinker.loadLibrary(context, "kiwix_wrapper");


### PR DESCRIPTION
Changed CMAKE_ANDROID_STL_TYPE to `shared` since it is not recommended to use `static` when we are using multiple dynamic libraries See conversation https://github.com/kiwix/java-libkiwix/issues/51.

