### PR TITLE
Moved `java-libkiwix` to new Maven repo.

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Libkiwix binding for Java/Kotlin
 
 Library for accessing [libkiwix](https://github.com/kiwix/libkiwix) and [libzim](https://github.com/openzim/libzim/) with Java or Kotlin on Android.
 
-[![Maven Central](https://img.shields.io/maven-central/v/org.kiwix.libkiwix/libkiwix)](https://search.maven.org/artifact/org.kiwix.libkiwix/libkiwix)
+[![Maven Central](https://img.shields.io/maven-central/v/org.kiwix/libkiwix)](https://search.maven.org/artifact/org.kiwix/libkiwix)
 [![Build Status](https://github.com/kiwix/java-libkiwix/workflows/CI/badge.svg?query=branch%3Amain)](https://github.com/kiwix/java-libkiwix/actions?query=workflow%3ACI+branch%3Amain)
 [![CodeFactor](https://www.codefactor.io/repository/github/kiwix/java-libkiwix/badge)](https://www.codefactor.io/repository/github/kiwix/java-libkiwix)
 [![Codecov](https://codecov.io/gh/kiwix/java-libkiwix/branch/main/graph/badge.svg)](https://codecov.io/gh/kiwix/java-libkiwix)

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -17,7 +17,7 @@ ext["ossrhPassword"] = properties.getProperty("ossrhPassword", System.getenv('OS
 ext["sonatypeStagingProfileId"] = properties.getProperty("sonatypeStagingProfileId", System.getenv('SONATYPE_STAGING_PROFILE_ID'))
 
 ext {
-    set("GROUP_ID", "org.kiwix.libkiwix")
+    set("GROUP_ID", "org.kiwix")
     set("ARTIFACT_ID", "libkiwix")
     set("VERSION", "1.0.0")
 }

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -23,8 +23,8 @@ ext {
 }
 
 // Replace these versions with the latest available versions of libkiwix and libzim
-ext.libkiwix_version = "12.0.0"
-ext.libzim_version = "8.2.0"
+ext.libkiwix_version = "12.1.0"
+ext.libzim_version = "8.2.1"
 
 apply from: 'publish.gradle'
 android {


### PR DESCRIPTION
Fixes #62 
Fixes #64

* We are moving our `java-libkiwix` to the new maven repo `org.kiwix` with version code `1.0.0`.
* Updated `README.md` file to use updated badge. Currently, it will show as "not found" (https://img.shields.io/maven-central/v/org.kiwix/libkiwix) because we have not yet published the artifact on Maven. Once we publish the artifact on Maven, it will start displaying correctly in the badge. 
* Previously, we were utilizing `libkiwix 12.0.0` and `libzim 8.2.0`. Now we are preparing to upload `java-libkiwix` on maven and new versions are available for these libraries. Hence, we're upgrading to `libkiwix 12.1.0` and `libzim 8.2.1`.