### PR TITLE
Do not the library in readOnly mode.

### DIFF
--- a/lib/src/main/cpp/libkiwix/manager.cpp
+++ b/lib/src/main/cpp/libkiwix/manager.cpp
@@ -41,7 +41,7 @@ METHOD(jboolean, readFile, jstring path)
 {
   auto cPath = TO_C(path);
 
-  return THIS->readFile(cPath);
+  return THIS->readFile(cPath, false);
 } CATCH_EXCEPTION(false)
 
 METHOD(jboolean, readXml, jstring content, jstring libraryPath)


### PR DESCRIPTION
The readOnly argument of `readFile` is to put the loaded library in readOnly mode. Which kinda means "Do not write again what is loaded".

We don't want that for android as we want to save again our (potentially modified) library.

See kiwix/kiwix-android#3474