### PR TITLE
Release `1.0.1`

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,8 @@
+1.0.1
+* FIX: Resolved an issue where the library was not saving all books that are read from the library. (https://github.com/kiwix/java-libkiwix/pull/72)
+* FIX: Fixed a problem where books were not returning the illustration. (https://github.com/kiwix/java-libkiwix/pull/74)
+
+
 1.0.0
 * NEW: Moved wrapper from libkiwix to java-libkiwix.
 * NEW: Adapted new build system.

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -19,7 +19,7 @@ ext["sonatypeStagingProfileId"] = properties.getProperty("sonatypeStagingProfile
 ext {
     set("GROUP_ID", "org.kiwix")
     set("ARTIFACT_ID", "libkiwix")
-    set("VERSION", "1.0.0")
+    set("VERSION", "1.0.1")
 }
 
 // Replace these versions with the latest available versions of libkiwix and libzim


### PR DESCRIPTION
Parent issue #75 

* Updated the CHANGELOG.
* Updated library version to `1.0.1`.