### PR TITLE
Allow `zim::Archive` to be created with a set of File descriptor.

### DIFF
--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -354,7 +354,8 @@ String getLibzimFiles() {
         "${projectDir}/src/main/java/org/kiwix/libzim/SuggestionSearcher.java " +
         "${projectDir}/src/main/java/org/kiwix/libzim/SuggestionSearch.java " +
         "${projectDir}/src/main/java/org/kiwix/libzim/ZimFileFormatException.java " +
-        "${projectDir}/src/main/java/org/kiwix/libzim/EntryNotFoundException.java"
+        "${projectDir}/src/main/java/org/kiwix/libzim/EntryNotFoundException.java " +
+        "${projectDir}/src/main/java/org/kiwix/libzim/FdInput.java"
 }
 
 task buildLinuxBinding(type: Exec) {

--- a/lib/src/main/cpp/libzim/archive.cpp
+++ b/lib/src/main/cpp/libzim/archive.cpp
@@ -64,16 +64,17 @@ int jni2fd(const jobject& fdObj, JNIEnv* env)
 
 zim::FdInput jni2fdInput(const jobject& fdInputObj, JNIEnv* env)
 {
-  jclass class_fdesc = env->FindClass("org/kiwix/FdInput");
-  jfieldID field_id = env->GetFieldID(class_fdesc, "fd", "java/io/FileDescriptor");
-  jobject fdObj = env->GetField(fdInputObj, field_id);
+  jclass class_fdesc = env->FindClass("org/kiwix/libzim/FdInput");
+
+  jfieldID field_id = env->GetFieldID(class_fdesc, "fd", "Ljava/io/FileDescriptor;");
+  jobject fdObj = env->GetObjectField(fdInputObj, field_id);
   int fd = jni2fd(fdObj, env);
 
   field_id = env->GetFieldID(class_fdesc, "offset", "J");
-  long offset = env->GetLongField(fdObj, field_id);
+  long offset = env->GetLongField(fdInputObj, field_id);
 
   field_id = env->GetFieldID(class_fdesc, "size", "J");
-  long size = env->GetLongField(fdObj, field_id);
+  long size = env->GetLongField(fdInputObj, field_id);
 
   return zim::FdInput(fd, offset, size);
 }
@@ -147,13 +148,13 @@ JNIEXPORT void JNICALL Java_org_kiwix_libzim_Archive_setNativeArchiveEmbeddedFds
 #ifndef _WIN32
 
   jsize length = env->GetArrayLength(fdsObj);
-  std::vector<zim::FdInput> v(length);
+  std::vector<zim::FdInput> v;
 
   int i;
   for(i = 0; i<length; i++) {
     jobject fdObj = env->GetObjectArrayElement(fdsObj, i);
     auto fdInput = jni2fdInput(fdObj, env);
-    v.push_pack(fdInput);
+    v.push_back(fdInput);
   }
 
   try {

--- a/lib/src/main/cpp/libzim/archive.cpp
+++ b/lib/src/main/cpp/libzim/archive.cpp
@@ -88,13 +88,8 @@ JNIEXPORT void JNICALL Java_org_kiwix_libzim_Archive_setNativeArchiveByFD(
   int fd = jni2fd(fdObj, env);
 
   LOG("Attempting to create reader with fd: %d", fd);
-  try {
-    auto archive = std::make_shared<zim::Archive>(fd);
-    SET_PTR(archive);
-  } catch (std::exception& e) {
-    LOG("Error opening ZIM file");
-       LOG("%s", e.what());
-  }
+  auto archive = std::make_shared<zim::Archive>(fd);
+  SET_PTR(archive);
 #else
   jclass exception = env->FindClass("java/lang/UnsupportedOperationException");
   env->ThrowNew(exception, "org.kiwix.libzim.Archive.setNativeArchiveByFD() is not supported under Windows");
@@ -108,13 +103,8 @@ JNIEXPORT void JNICALL Java_org_kiwix_libzim_Archive_setNativeArchiveEmbedded(
   int fd = jni2fd(fdObj, env);
 
   LOG("Attempting to create reader with fd: %d", fd);
-  try {
-    auto archive = std::make_shared<zim::Archive>(fd, offset, size);
-    SET_PTR(archive);
-  } catch (std::exception& e) {
-    LOG("Error opening ZIM file");
-       LOG("%s", e.what());
-  }
+  auto archive = std::make_shared<zim::Archive>(fd, offset, size);
+  SET_PTR(archive);
 #else
   jclass exception = env->FindClass("java/lang/UnsupportedOperationException");
   env->ThrowNew(exception, "org.kiwix.libzim.Archive.setNativeArchiveEmbedded() is not supported under Windows");
@@ -127,14 +117,8 @@ JNIEXPORT void JNICALL Java_org_kiwix_libzim_Archive_setNativeArchiveEmbeddedFd(
 #ifndef _WIN32
   auto fdInput = jni2fdInput(fdObj, env);
 
-  LOG("Attempting to create reader with fd: %d", fdInput);
-  try {
-    auto archive = std::make_shared<zim::Archive>(fdInput);
-    SET_PTR(archive);
-  } catch (std::exception& e) {
-    LOG("Error opening ZIM file");
-       LOG("%s", e.what());
-  }
+  auto archive = std::make_shared<zim::Archive>(fdInput);
+  SET_PTR(archive);
 #else
   jclass exception = env->FindClass("java/lang/UnsupportedOperationException");
   env->ThrowNew(exception, "org.kiwix.libzim.Archive.setNativeArchiveEmbedded() is not supported under Windows");
@@ -157,13 +141,8 @@ JNIEXPORT void JNICALL Java_org_kiwix_libzim_Archive_setNativeArchiveEmbeddedFds
     v.push_back(fdInput);
   }
 
-  try {
-    auto archive = std::make_shared<zim::Archive>(v);
-    SET_PTR(archive);
-  } catch (std::exception& e) {
-    LOG("Error opening ZIM file");
-       LOG("%s", e.what());
-  }
+  auto archive = std::make_shared<zim::Archive>(v);
+  SET_PTR(archive);
 #else
   jclass exception = env->FindClass("java/lang/UnsupportedOperationException");
   env->ThrowNew(exception, "org.kiwix.libzim.Archive.setNativeArchiveEmbedded() is not supported under Windows");

--- a/lib/src/main/java/org/kiwix/libzim/Archive.java
+++ b/lib/src/main/java/org/kiwix/libzim/Archive.java
@@ -23,6 +23,7 @@ import org.kiwix.libzim.ZimFileFormatException;
 import org.kiwix.libzim.Entry;
 import org.kiwix.libzim.Item;
 import org.kiwix.libzim.EntryIterator;
+import org.kiwix.libzim.FdInput;
 import java.io.FileDescriptor;
 
 public class Archive
@@ -42,6 +43,18 @@ public class Archive
           throws ZimFileFormatException
   {
     setNativeArchiveEmbedded(fd, offset, size);
+  }
+
+  public Archive(FdInput fd)
+  throws ZimFileFormatException
+  {
+    setNativeArchiveEmbeddedFd(fd);
+  }
+
+  public Archive(FdInput[] fds)
+  throws ZimFileFormatException
+  {
+    setNativeArchiveEmbeddedFds(fds);
   }
 
   public native String getFilename();
@@ -94,6 +107,8 @@ public class Archive
   private native void setNativeArchive(String filename);
   private native void setNativeArchiveByFD(FileDescriptor fd);
   private native void setNativeArchiveEmbedded(FileDescriptor fd, long offset, long size);
+  private native void setNativeArchiveEmbeddedFd(FdInput fd);
+  private native void setNativeArchiveEmbeddedFds(FdInput[] fds);
 
   @Override
   protected void finalize() { dispose(); }

--- a/lib/src/main/java/org/kiwix/libzim/FdInput.java
+++ b/lib/src/main/java/org/kiwix/libzim/FdInput.java
@@ -26,4 +26,10 @@ public class FdInput
   public FileDescriptor fd;
   public long offset;
   public long size;
+
+  public FdInput(FileDescriptor fd_, long offset_, long size_) {
+    fd = fd_;
+    offset = offset_;
+    size = size_;
+  }
 }

--- a/lib/src/main/java/org/kiwix/libzim/FdInput.java
+++ b/lib/src/main/java/org/kiwix/libzim/FdInput.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C) 2017 Matthieu Gautier <mgautier@kymeria.fr>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU  General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA 02110-1301, USA.
+ */
+
+package org.kiwix.libzim;
+
+import java.io.FileDescriptor;
+
+public class FdInput
+{
+  public FileDescriptor fd;
+  public long offset;
+  public long size;
+}

--- a/lib/src/test/org/kiwix/test/libzim/TestArchive.java
+++ b/lib/src/test/org/kiwix/test/libzim/TestArchive.java
@@ -47,6 +47,18 @@ public class TestArchive
     inner = new Archive(fd, offset, size);
   }
 
+  public TestArchive(FdInput fd)
+          throws ZimFileFormatException
+  {
+    inner = new Archive(fd);
+  }
+
+  public TestArchive(FdInput[] fds)
+          throws ZimFileFormatException
+  {
+    inner = new Archive(fds);
+  }
+
   public String getFilename() { return inner.getFilename(); }
   public long getFilesize() { return inner.getFilesize(); }
   public int getAllEntryCount() { return inner.getAllEntryCount(); }


### PR DESCRIPTION
This PR is in Draft as it wrap a feature in libzim not yet released.
Once new libzim is released, we have still have to change gradle script to use it and then we should be good.