### PR TITLE
Fixed: CD is failing.

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -12,11 +12,11 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Set up JDK 11
+      - name: Set up JDK 17
         uses: actions/setup-java@v4
         with:
           distribution: adopt
-          java-version: 11
+          java-version: 17
 
       - name: Install dependencies
         run: bash ./install_deps.sh


### PR DESCRIPTION
Fixes #100 

It was because we were using java 11 in CD, and now our project requires java 17 to run.