### PR TITLE
Fixed: The CD is failing because the new gradle version gives an error for the lib:generateMetadataFileForReleasePublication task.

### DIFF
--- a/lib/publish.gradle
+++ b/lib/publish.gradle
@@ -71,6 +71,13 @@ afterEvaluate {
             }
         }
     }
+
+    // Set dependency for the metadata file generation task
+    tasks.withType(GenerateModuleMetadata).tap {
+        configureEach {
+            dependsOn tasks.named("androidSourcesJar")
+        }
+    }
 }
 
 signing {


### PR DESCRIPTION
Fixes #103 

* The issue occurred because `generateMetadataFileForReleasePublication` uses the output of the `androidSourcesJar` task, but no dependency was declared on this task. This can lead to incorrect results being produced due to the tasks executing in the wrong order. To fix this, we added an explicit dependency on the `GenerateModuleMetadata` tasks, ensuring that all `GenerateModuleMetadata` tasks run after the `androidSourcesJar` task.