### PR TITLE
Fixed: CD is failing because there are multiple jar and sources files to upload.

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -22,7 +22,7 @@ jobs:
         run: bash ./install_deps.sh
 
       - name: Compile and prepare package
-        run: ./gradlew buildHeaders build assemble androidSourcesJar
+        run: ./gradlew buildHeaders build assemble
 
       - name: Publish to Maven Central
         run: ./gradlew publishReleasePublicationToSonatypeRepository --max-workers 1 closeAndReleaseSonatypeStagingRepository

--- a/lib/publish.gradle
+++ b/lib/publish.gradle
@@ -1,23 +1,6 @@
 apply plugin: 'maven-publish'
 apply plugin: 'signing'
 
-tasks.register('androidSourcesJar', Jar) {
-    archiveClassifier.set('sources')
-    if (project.plugins.findPlugin("com.android.library")) {
-        // For Android libraries
-        from android.sourceSets.main.java.srcDirs
-        from android.sourceSets.main.kotlin.srcDirs
-    } else {
-        // For pure Kotlin libraries, in case you have them
-        from sourceSets.main.java.srcDirs
-        from sourceSets.main.kotlin.srcDirs
-    }
-}
-
-artifacts {
-    archives androidSourcesJar
-}
-
 def siteUrl = 'https://www.kiwix.org/en/'
 def gitUrl = 'https://github.com/kiwix/libkiwix.git'
 
@@ -35,7 +18,6 @@ afterEvaluate {
 
                 from components.release
 
-                artifact androidSourcesJar
                 pom {
                     name = ARTIFACT_ID
                     description = 'LibKiwix Android library'
@@ -69,13 +51,6 @@ afterEvaluate {
                     password = ossrhPassword
                 }
             }
-        }
-    }
-
-    // Set dependency for the metadata file generation task
-    tasks.withType(GenerateModuleMetadata).tap {
-        configureEach {
-            dependsOn tasks.named("androidSourcesJar")
         }
     }
 }


### PR DESCRIPTION
Fixes #105 

It was due to we had upgraded the Nexus plugin while upgrading the gradle. So this new version of Nexus generates the sources and jar files itself, and we have a task where we are generating the sources and jar so due to this it detected the multiple jar and sources files and failed the CD. So we have removed our task so that the Nexus plugin will generate and upload the jar and source files itself.