### PR TITLE
Updated the README file to show the required `Java version` to compile the project.

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ Library for accessing [libkiwix](https://github.com/kiwix/libkiwix) and [libzim]
 
 # Build
 
+The project requires `Java 17` to compile, Therefore set the `Gradle JDK` to `Java 17`.
+
 ## Install dependencies
 ```bash
 ./install_deps.sh


### PR DESCRIPTION
Setting the `JAVA version` to 17 is a prerequisites to compile the project. Since now our project is compatible with Android 14(SDK 34) which requires version `8.4` of Gradle, and this Gradle version requires java 17 to run. So it should be added in the readme file so that user will not face this issue while building the binding. This is the only prerequisite to compile the project.