### PR TITLE
Fixed the native crash happening on Android.

### DIFF
--- a/lib/src/main/cpp/macros.h
+++ b/lib/src/main/cpp/macros.h
@@ -53,6 +53,9 @@ catch(const zim::ZimFileFormatError& e) { \
 } catch(const zim::EntryNotFound& e) { \
   throwException(env, "org/kiwix/libzim/EntryNotFoundException", e.what()); \
   return RET; \
+} catch (const NativeHandleDisposedException& e) { \
+  throwException(env, "java/lang/IllegalStateException", e.what()); \
+  return RET; \
 } catch (const std::ios_base::failure& e) { \
   throwException(env, "java/io/IOException", e.what()); \
   return RET; \

--- a/lib/src/main/cpp/utils.h
+++ b/lib/src/main/cpp/utils.h
@@ -110,7 +110,7 @@ shared_ptr<T> getPtr(JNIEnv* env, jobject thisObj, const char* handleName = "nat
   jfieldID fidNumber = env->GetFieldID(thisClass, handleName, "J");
   auto handle = reinterpret_cast<shared_ptr<T>*>(env->GetLongField(thisObj, fidNumber));
   if (handle == nullptr) {
-      throw NativeHandleDisposedException("The native object is already has been disposed");
+      throw NativeHandleDisposedException("The native object has already been disposed");
   }
   return *handle;
 }


### PR DESCRIPTION
See issue https://github.com/kiwix/kiwix-android/issues/3956

* The issue on the Android side was a `null pointer dereference`, meaning that when accessing the getEntryByPath method, the archive object had already been disposed of, which caused the crash.
* We are correctly handling and disposing of the previous archive and web views for the previously set archive. However, web views load content on their own thread. When we change the ZIM file, we dispose of the previous archive and stop the ongoing web view processes. In certain cases, the web view internally tries to get content via the getEntryByPath method because it takes some time to cancel all the previous calls on the background thread. As a result, the web view attempts to call the method on a disposed archive, which causes the native crash.
* To fix this, I refactored the `getPtr` method to throw `NativeHandleDisposedException` if the archive has already been disposed, and handled this custom error in the `CATCH_EXCEPTION` macro. Now, instead of crashing the entire program, it correctly throws an error, which is handled by Kiwix.


* Handling this scenario on the Android side is not feasible since the WebView operates on a separate thread over which we have no control. However, addressing this issue on the java-libkiwix side is a better approach. If an object is already disposed, it should throw an error that can be caught by the caller, instead of crashing the entire program. Handling such errors is the responsibility of the user of `java-libkiwix` (e.g., Kiwix Android). We are already handling all errors thrown by `java-libkiwix` in the Kiwix Android app.


The issue sometimes occurs on the CI see https://github.com/kiwix/kiwix-android/actions/runs/12809338048/job/35713951704?pr=4177#step:8:9560