### PR TITLE
Refactored the publishing plugin to upload binaries to the "Central Portal".

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -28,8 +28,8 @@ jobs:
         run: ./gradlew publishReleasePublicationToSonatypeRepository --max-workers 1 closeAndReleaseSonatypeStagingRepository
         if: github.event_name == 'release'
         env:
-          OSSRH_USERNAME: ${{ secrets.OSSRH_USERNAME }}
-          OSSRH_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
+          SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
+          SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
           SIGNING_KEY_ID: ${{ secrets.SIGNING_KEY_ID }}
           SIGNING_PASSWORD: ${{ secrets.SIGNING_PASSWORD }}
           SIGNING_KEY: ${{ secrets.SIGNING_KEY }}

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         maven { url 'https://plugins.gradle.org/m2/' }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.1.3'
+        classpath 'com.android.tools.build:gradle:8.11.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.9.20"
         classpath 'io.github.gradle-nexus:publish-plugin:2.0.0'
         classpath 'de.undercouch:gradle-download-task:5.3.0'
@@ -30,10 +30,10 @@ nexusPublishing {
     repositories {
         sonatype {
             stagingProfileId = properties.getProperty("sonatypeStagingProfileId", System.getenv('SONATYPE_STAGING_PROFILE_ID'))
-            username = properties.getProperty("ossrhUsername", System.getenv('OSSRH_USERNAME'))
-            password = properties.getProperty("ossrhPassword", System.getenv('OSSRH_PASSWORD'))
-            nexusUrl.set(uri("https://s01.oss.sonatype.org/service/local/"))
-            snapshotRepositoryUrl.set(uri("https://s01.oss.sonatype.org/content/repositories/snapshots/"))
+            username = properties.getProperty("sonatypeUsername", System.getenv('SONATYPE_USERNAME'))
+            password = properties.getProperty("sonatypePassword", System.getenv('SONATYPE_PASSWORD'))
+            nexusUrl.set(uri("https://ossrh-staging-api.central.sonatype.com/service/local/"))
+            snapshotRepositoryUrl.set(uri("https://central.sonatype.com/repository/maven-snapshots/"))
     }
 }
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Fri Aug 12 19:44:15 IST 2022
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-bin.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -12,8 +12,8 @@ if (rootProject.file("local.properties").exists()) {
 ext["keyId"] = properties.getProperty("signing.keyId", System.getenv('SIGNING_KEY_ID'))
 ext["password"] = properties.getProperty("signing.password", System.getenv('SIGNING_PASSWORD'))
 ext["key"] = properties.getProperty("signing.key", System.getenv('SIGNING_KEY'))
-ext["ossrhUsername"] = properties.getProperty("ossrhUsername", System.getenv('OSSRH_USERNAME'))
-ext["ossrhPassword"] = properties.getProperty("ossrhPassword", System.getenv('OSSRH_PASSWORD'))
+ext["sonatypeUsername"] = properties.getProperty("sonatypeUsername", System.getenv('SONATYPE_USERNAME'))
+ext["sonatypePassword"] = properties.getProperty("sonatypePassword", System.getenv('SONATYPE_PASSWORD'))
 ext["sonatypeStagingProfileId"] = properties.getProperty("sonatypeStagingProfileId", System.getenv('SONATYPE_STAGING_PROFILE_ID'))
 
 ext {
@@ -95,7 +95,7 @@ android {
         abortOnError true
         checkAllWarnings = true
         warningsAsErrors true
-        disable("GradleDependency", "UnknownNullness", "OldTargetApi")
+        disable("GradleDependency", "UnknownNullness", "OldTargetApi", "AndroidGradlePluginVersion")
     }
 }
 

--- a/lib/publish.gradle
+++ b/lib/publish.gradle
@@ -45,10 +45,10 @@ afterEvaluate {
         }
         repositories {
             maven {
-                url = uri("https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/")
+                url = uri("https://ossrh-staging-api.central.sonatype.com/service/local/staging/deploy/maven2/")
                 credentials {
-                    username = ossrhUsername
-                    password = ossrhPassword
+                    username = sonatypeUsername
+                    password = sonatypePassword
                 }
             }
         }


### PR DESCRIPTION
See https://github.com/kiwix/java-libkiwix/issues/122

* The new publishing process now uses token-based credentials (userName and password) generated from the "Central Portal", so we updated our code accordingly.
* Upgraded Gradle to version `8.11.1`, as the previous version was showing warnings for the `riscv64` architecture after upgrading the NDK. See https://github.com/kiwix/java-libkiwix/actions/runs/19072194798/job/54477795136#step:5:10
* Updated our CD pipeline to retrieve the new `SONATYPE_USERNAME` and `SONATYPE_PASSWORD` from GitHub Secrets.