### PR TITLE
Release `2.5.0`.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+2.5.0
+* NEW: Use libkiwix 14.2.0 (@MohitMaliFtechiz https://github.com/kiwix/java-libkiwix/pull/142)
+* NEW: Added Manager::addBooksFromDirectory, allowing the server to load all books from a specified directory (@MohitMaliFtechiz https://github.com/kiwix/java-libkiwix/pull/142)
+
 2.4.2
 * NEW: Use libkiwix 14.1.1-1 (@kelson42 https://github.com/kiwix/java-libkiwix/pull/140)
 * NEW: Use libzim 9.5.0 (@kelson42 , @MohitMaliFtechiz https://github.com/kiwix/java-libkiwix/pull/140)

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -19,7 +19,7 @@ ext["sonatypeStagingProfileId"] = properties.getProperty("sonatypeStagingProfile
 ext {
     set("GROUP_ID", "org.kiwix")
     set("ARTIFACT_ID", "libkiwix")
-    set("VERSION", "2.4.2")
+    set("VERSION", "2.5.0")
 }
 
 // Replace these versions with the latest available versions of libkiwix and libzim


### PR DESCRIPTION
Parent Issue #136 

* Updated the CHANGELOG file.
* Updated the version of java-libkiwix to `2.5.0`.